### PR TITLE
[IMP] academic: avoid dependency to purchase module

### DIFF
--- a/academic/__manifest__.py
+++ b/academic/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Academic',
-    'version': '13.0.1.1.0',
+    'version': '13.0.1.2.0',
     'sequence': 14,
     'summary': '',
     'author': 'ADHOC SA',
@@ -33,7 +33,6 @@
         'hr',
         'website',
         'board',
-        'purchase',
         'sale_management',
         'account',
     ],

--- a/academic/views/res_partner_views.xml
+++ b/academic/views/res_partner_views.xml
@@ -82,10 +82,6 @@
                 <field name="section_id" placeholder="Section..." attrs="{'invisible':[('partner_type','!=','administrator')],'required':[('partner_type','=','administrator')]}"/>
             </field>
 
-            <page name="sales_purchases" position="attributes">
-                <attribute name="groups">purchase.group_purchase_user,sales_team.group_sale_salesman,account.group_account_invoice</attribute>
-            </page>
-
         <!-- pop up contactos -->
             <xpath expr="//field[@name='child_ids']//form//field[@name='name']" position="before">
                 <field name="is_company" invisible="1"/>


### PR DESCRIPTION
This modification of the res.parnter view was only for old apdes project.
We avoid this dependency as some customer (dailan for eg) dont' want to use purchases.