### PR TITLE
[FIX] academic: error for users with more than one student group

### DIFF
--- a/academic/models/res_partner.py
+++ b/academic/models/res_partner.py
@@ -184,9 +184,7 @@ class ResPartner(models.Model):
     def _compute_current_main_group(self):
         for rec in self:
             student_group = rec.student_group_ids.filtered(lambda g: g.year == date.today().year and not g.subject_id)
-            if len(student_group) > 1:
-                raise ValidationError("There shouldn't be two groups in the same year without a subject for partner %s." % rec.name)
-            rec.current_main_group_id = student_group
+            rec.current_main_group_id = student_group[:1]
 
     @api.model
     def get_payment_responsible(self):


### PR DESCRIPTION
Cuando hay más de un grupo tira el error y no deja crear una base new por lo tanto para que no de error tomo el primero que encuentre

En la creación de la siguiente base salió el error:
https://www.adhoc.com.ar/web#id=5727&cids=3-1-42&menu_id=5540&model=helpdesk.ticket.upgrade.request&view_type=form