### PR TITLE
[IMP] academic_sale_subscription: improvements in wizard

### DIFF
--- a/academic_sale_subscription/__manifest__.py
+++ b/academic_sale_subscription/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Academic Sale Subscription',
-    'version': "17.0.1.4.0",
+    'version': "17.0.1.5.0",
     'sequence': 14,
     'summary': '',
     'author': 'ADHOC SA',

--- a/academic_sale_subscription/wizard/academic_order_wizard.py
+++ b/academic_sale_subscription/wizard/academic_order_wizard.py
@@ -87,6 +87,11 @@ class OrderWizard(models.TransientModel):
         for rec in self:
             order_wizard_lines = []
 
+            # deletion of lines created from another template
+            lines_to_remove = rec.order_wizard_line_ids.filtered(lambda x: x.template_id and x.template_id != rec.template_id)
+            for line in lines_to_remove:
+                order_wizard_lines.append(Command.unlink(line.id))
+
             if rec.template_id:
                 for line in rec.template_id.sale_order_template_line_ids:
                     existing_line = rec.order_wizard_line_ids.filtered(lambda l: l.product_id.id == line.product_id.id)
@@ -103,6 +108,7 @@ class OrderWizard(models.TransientModel):
                             'product_id': line.product_id.id,
                             'price': pricing.price if pricing else 0.0,
                             'quantity': line.product_uom_qty,
+                            'template_id': rec.template_id,
                         }
                         order_wizard_lines.append(Command.create(order_wizard_line_vals))
 
@@ -150,6 +156,7 @@ class AcademicOrderWizardLine(models.TransientModel):
     currency_id = fields.Many2one('res.currency', default=lambda self: self.env.company.currency_id)
     description = fields.Text()
     quantity = fields.Float(default=1.0)
+    template_id = fields.Many2one('sale.order.template', store=False)
 
     @api.depends('product_id')
     def _compute_price(self):

--- a/academic_sale_subscription/wizard/academic_order_wizard_views.xml
+++ b/academic_sale_subscription/wizard/academic_order_wizard_views.xml
@@ -22,6 +22,7 @@
                     <page string="Lines" name="lines">
                         <field name="order_wizard_line_ids">
                             <tree editable="1">
+                                <field name="template_id" column_invisible="1"/>
                                 <field name="product_id"/>
                                 <field name="price"/>
                                 <field name="quantity"/>


### PR DESCRIPTION
El template_id no necesitamos que sea store porque es simplemente un hack para borrar productos en las líneas.
Tampoco necesitamos que se vea pero es necesario ponerlo ya que sino no se guarda el dato virtualmente. 