### PR TITLE
[FIX] academic_payment_portal: force partner_id on portal payments to…

### DIFF
--- a/academic_payment_portal/models/__init__.py
+++ b/academic_payment_portal/models/__init__.py
@@ -1,3 +1,5 @@
 from . import account_move
 from . import res_company
 from . import res_partner
+from . import account_payment
+from . import payment_transaction

--- a/academic_payment_portal/models/account_payment.py
+++ b/academic_payment_portal/models/account_payment.py
@@ -1,0 +1,13 @@
+from odoo import api,  models
+
+
+class AccountPayment(models.Model):
+    _inherit = 'account.payment'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        transaction_force_partner_id = self.env.context.get('transaction_force_partner_id')
+        for vals in vals_list:
+            if vals.get('payment_transaction_id') and transaction_force_partner_id:
+                vals['partner_id'] = transaction_force_partner_id.commercial_partner_id.id
+        return super().create(vals_list)

--- a/academic_payment_portal/models/payment_transaction.py
+++ b/academic_payment_portal/models/payment_transaction.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class PaymentTransaction(models.Model):
+    _inherit = 'payment.transaction'
+
+    def _create_payment(self, **extra_create_values):
+        self.ensure_one()
+
+        partner_id = self.super().mapped("invoice_ids.partner_id")
+        if len(partner_id) == 1 and self.partner_id.commercial_partner_id != partner_id[0].commercial_partner_id:
+            return super(PaymentTransaction, self.with_context(transaction_force_partner_id=partner_id))._create_payment(**extra_create_values)
+        return super()._create_payment(**extra_create_values)


### PR DESCRIPTION
… reconcile invoices

When a payment is created from the portal and the payer does not belong to the same commercial partner as the invoice, we force the payment partner_id to the invoice commercial partner.

In Academic, parent users can view and pay their children’s invoices, but that relationship is modeled through an academic family, not through commercial partners. Without this adjustment, automatic reconciliation between invoice payments and invoices fails.