### PR TITLE
[IMP] academic_account_interests: sync debt traceability logic with a…

### DIFF
--- a/academic_account_interests/models/res_company_interest.py
+++ b/academic_account_interests/models/res_company_interest.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models
+from odoo import _, models
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -41,20 +41,33 @@ class ResCompanyInterest(models.Model):
         }
 
         # Deudas de períodos anteriores
-        previous_grouped_lines = self.env["account.move.line"]._read_group(
-            domain=self._get_move_line_domains()
-            + [("full_reconcile_id", "=", False), ("date_maturity", "<", from_date)],
-            groupby=groupby,
-            aggregates=["amount_residual:sum"],
+        previous_lines = self.env["account.move.line"].search(
+            self._get_move_line_domains()
+            + [
+                ("full_reconcile_id", "=", False),
+                ("amount_residual", ">", 0),
+                ("date_maturity", "<", from_date),
+            ]
         )
-        for x in previous_grouped_lines:
-            self._update_deuda(
-                deuda,
-                x[0],
-                "Deuda periodos anteriores",
-                x[2] * self.with_context(debt_past_period=True)._calculate_rate() * self.interval,
-            )
-            deuda[x[0]]["partner_id"] = x[1]
+        past_due_rate = self.with_context(debt_past_period=True)._calculate_rate()
+        for line in previous_lines:
+            student = line[groupby[0]] if groupby else line.student_id
+            partner = line[groupby[1]] if groupby and len(groupby) > 1 else line.partner_id
+            if not student or not partner:
+                continue
+
+            residual_amount = line.amount_residual
+            interest = residual_amount * past_due_rate * self.interval
+            detail = _(
+                "- Invoice %(invoice_name)s: Residual %(residual)s x %(interval)s periods -> Interest: %(interest)s"
+            ) % {
+                "invoice_name": line.move_id.name or line.move_name or "-",
+                "residual": round(residual_amount, 2),
+                "interval": self.interval,
+                "interest": round(interest, 2),
+            }
+            self._update_deuda(deuda, student, "Deuda periodos anteriores", interest, detail)
+            deuda[student]["values"]["partner_id"] = partner
 
         # Intereses por el último período
         last_period_lines = self.env["account.move.line"].search(
@@ -62,14 +75,32 @@ class ResCompanyInterest(models.Model):
             + [("amount_residual", ">", 0), ("date_maturity", ">=", from_date), ("date_maturity", "<", to_date)]
         )
         for student, amls in last_period_lines.grouped("student_id").items():
-            interest = sum(
-                move.amount_residual
-                * ((to_date - move.invoice_date_due).days)
-                * (self._calculate_rate() / interest_rate[self.rule_type])
-                for move, lines in amls.grouped("move_id").items()
-            )
-            self._update_deuda(deuda, student, "Deuda último periodo", interest)
-            deuda[student]["partner_id"] = amls[0].partner_id
+            if not student:
+                continue
+            partner = amls[:1].partner_id
+            if not partner:
+                continue
+
+            for move, lines in amls.grouped("move_id").items():
+                due_date = move.invoice_date_due or lines[:1].date_maturity
+                if not due_date:
+                    continue
+                days = max((to_date - due_date).days, 0)
+                residual_amount = move.amount_residual
+                interest = residual_amount * days * (self._calculate_rate() / interest_rate[self.rule_type])
+                detail = _(
+                    "- Invoice %(invoice_name)s: Due %(due_date)s | Residual %(residual)s x %(days)s days -> Interest: %(interest)s"
+                ) % {
+                    "invoice_name": move.name or lines[:1].move_name or "-",
+                    "due_date": due_date,
+                    "residual": round(residual_amount, 2),
+                    "days": days,
+                    "interest": round(interest, 2),
+                }
+                self._update_deuda(deuda, student, "Deuda último periodo", interest, detail)
+
+            if student in deuda:
+                deuda[student]["values"]["partner_id"] = partner
 
         # Intereses por pagos tardíos
         if self.late_payment_interest:
@@ -84,24 +115,39 @@ class ResCompanyInterest(models.Model):
             ]
 
             if self.domain:
-                partial_domain.append(("debit_move_id", "any", safe_eval(self.domain)))
+                partial_domain.append(("debit_move_id", "any", safe_eval(self.domain, self._get_eval_context())))
 
             partials = (
                 self.env["account.partial.reconcile"]
                 .search(partial_domain)
-                .filtered(lambda x: x.credit_move_id.date > x.debit_move_id.date_maturity)
+                .filtered(
+                    lambda x: x.debit_move_id.date_maturity and x.credit_move_id.date > x.debit_move_id.date_maturity
+                )
                 .grouped("debit_move_id")
             )
 
             for move_line, parts in partials.items():
+                student = move_line.student_id
+                partner = move_line.partner_id
+                if not student or not partner:
+                    continue
                 for part in parts:
                     due_date = max(from_date, part.debit_move_id.date_maturity)
 
                     days = (part.credit_move_id.date - due_date).days
                     interest = part.amount * days * (self._calculate_rate() / interest_rate[self.rule_type])
-                    # Se debe actualiza la deuda del partner, por ello se llama al cliente metodo para su actualizacion
-                    self._update_deuda(deuda, move_line.student_id, "Deuda pagos vencidos", interest)
-                deuda[move_line.student_id]["partner_id"] = move_line.partner_id
+                    detail = _(
+                        "- Payment %(payment_name)s applied to %(invoice_name)s on %(payment_date)s -> Interest: %(interest)s"
+                    ) % {
+                        "payment_name": part.credit_move_id.move_id.name or part.credit_move_id.name or "-",
+                        "invoice_name": part.debit_move_id.move_id.name or part.debit_move_id.name or "-",
+                        "payment_date": part.credit_move_id.date,
+                        "interest": round(interest, 2),
+                    }
+                    self._update_deuda(deuda, student, "Deuda pagos vencidos", interest, detail)
+
+                if student in deuda:
+                    deuda[student]["values"]["partner_id"] = partner
 
         return deuda
 


### PR DESCRIPTION
…ccount_interests

Refactor _calculate_debts to align with the new traceable structure: keep aggregated amounts under values
store per-calculation audit lines under details
Replace previous-period grouped aggregation with per-line calculation to preserve invoice-level traceability Add detailed trace messages for:
 - previous-period debt interest
 - last-period overdue interest
 - late-payment interest Preserve academic behavior by keeping student_id as grouping key and storing mapped partner_id in values["partner_id"] Update academic overrides to support new debt payload safely: _search_last_journal_for_partner now reads partner with fallback (debt.get("partner_id", partner)) _prepare_interest_invoice now reads partner with fallback and keeps student_id/partner_id assignment in move values Align late-payment domain evaluation with eval context (safe_eval(..., self._get_eval_context())) Keep existing sale journal filtering in _get_move_line_domains