### PR TITLE
[FIX] academic_payment_portal: fix multi-invoice payment for Responsable de Pago

### DIFF
--- a/academic_payment_portal/__init__.py
+++ b/academic_payment_portal/__init__.py
@@ -1,2 +1,3 @@
+from . import controllers
 from . import models
 from . import wizards

--- a/academic_payment_portal/controllers/__init__.py
+++ b/academic_payment_portal/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import portal

--- a/academic_payment_portal/controllers/portal.py
+++ b/academic_payment_portal/controllers/portal.py
@@ -1,0 +1,16 @@
+from odoo.http import request
+
+try:
+    from odoo.addons.account_payment_multi.controllers.portal import PaymentPortal
+
+    class PaymentPortal(PaymentPortal):
+        def _get_selected_invoices_domain(self, due_date, partner_id=None):
+            if not partner_id:
+                invoice_id = request.params.get('invoice_id')
+                if invoice_id:
+                    invoice = request.env['account.move'].sudo().browse(int(invoice_id))
+                    partner_id = invoice.partner_id.id
+            return super()._get_selected_invoices_domain(due_date, partner_id=partner_id)
+
+except ImportError:
+    pass


### PR DESCRIPTION
Override _get_selected_invoices_domain to use the invoice partner_id
    instead of the logged-in user partner. When a Responsable de Pago
    pays a student invoice, the domain was filtering by their own partner
    returning an empty result set and causing a 500 error.