### PR TITLE
[IMP] academic_sale_subscription: show invoices where user is follower in portal

### DIFF
--- a/academic_sale_subscription/controllers/portal_account.py
+++ b/academic_sale_subscription/controllers/portal_account.py
@@ -30,18 +30,42 @@ class PortalAccount(PortalAccount):
         if filterby not in searchbar_filters:
             filterby = "all"
         values = super()._prepare_my_invoices_values(page, date_begin, date_end, sortby, filterby, domain, url)
+
+        partner = request.env.user.partner_id
+        AccountInvoice = request.env["account.move"].sudo()
+
         domain = Domain.AND(
             [
                 domain or [],
                 self._get_invoices_domain(),
+                [
+                    "|",
+                    ("partner_id", "child_of", [partner.commercial_partner_id.id]),
+                    ("message_partner_ids", "in", [partner.id]),
+                ],
             ]
         )
         domain += searchbar_filters[filterby]["domain"]
-        invoices = request.env["account.move"].search(domain)
+
+        order = self._get_account_searchbar_sortings().get(sortby or "date", {}).get("order", "invoice_date desc")
+
+        invoices = AccountInvoice.search(domain)
+        total = len(invoices)
         total_amount_due = (
             sum(invoices.mapped(lambda x: -x.amount_residual if x.move_type == "out_refund" else x.amount_residual))
             if invoices
             else 0.0
         )
-        values.update({"total_amount_due": total_amount_due})
+        values.update(
+            {
+                "total_amount_due": total_amount_due,
+                "invoices": lambda pager_offset: [
+                    invoice._get_invoice_portal_extra_values()
+                    for invoice in AccountInvoice.search(
+                        domain, order=order, limit=self._items_per_page, offset=pager_offset
+                    )
+                ],
+                "pager": {**values["pager"], "total": total},
+            }
+        )
         return values


### PR DESCRIPTION
> 🎫 **Helpdesk ticket** #117495

## Changes

- [IMP] academic_sale_subscription: show invoices where user is follower in portal

  Uses sudo() + manual auth domain to include invoices where the portal user
  is a follower (message_partner_ids), in addition to being the invoice partner.

## Related

Helpdesk ticket: #117495
Branch: `19.0-h-117495-gal`
