### PR TITLE
[FIX] academic_payment_portal: filter invoices by payment responsible

### DIFF
--- a/academic_payment_portal/__manifest__.py
+++ b/academic_payment_portal/__manifest__.py
@@ -26,7 +26,7 @@
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',
     'depends': [
-        'account_payment'
+        'account_payment_multi',
     ],
     'data': [
         'wizards/res_config_setting_views.xml',

--- a/academic_payment_portal/controllers/portal.py
+++ b/academic_payment_portal/controllers/portal.py
@@ -1,16 +1,25 @@
 from odoo.http import request
+from odoo.addons.account_payment_multi.controllers.portal import PaymentPortal
 
-try:
-    from odoo.addons.account_payment_multi.controllers.portal import PaymentPortal
-
-    class PaymentPortal(PaymentPortal):
-        def _get_selected_invoices_domain(self, due_date, partner_id=None):
-            if not partner_id:
-                invoice_id = request.params.get('invoice_id')
-                if invoice_id:
-                    invoice = request.env['account.move'].sudo().browse(int(invoice_id))
-                    partner_id = invoice.partner_id.id
-            return super()._get_selected_invoices_domain(due_date, partner_id=partner_id)
-
-except ImportError:
-    pass
+class PaymentPortal(PaymentPortal):
+    def _get_selected_invoices_domain(self, due_date, partner_id=None):
+        # En contexto académico, el usuario logueado debe ser responsable de pago del estudiante
+        # No usamos el partner_id de la factura porque este es el estudiante, no el responsable
+        if not partner_id:
+            partner_id = request.env.user.partner_id.id
+        
+        # Construimos dominio base
+        domain = [
+            ('state', 'not in', ('cancel', 'draft')),
+            ('move_type', 'in', ('out_invoice', 'out_receipt')),
+            ('payment_state', 'not in', ('in_payment', 'paid')),
+            ('invoice_date_due', '<=', due_date),
+        ]
+        
+        # Filtramos por facturas donde el usuario es responsable de pago del estudiante
+        # o donde el usuario es el partner directo de la factura
+        domain.append('|')
+        domain.append(('student_id.payment_responsible_ids', 'in', partner_id))
+        domain.append(('partner_id', '=', partner_id))
+        
+        return domain


### PR DESCRIPTION
When a payment responsible user logs into the portal, they should only see invoices for students where they are listed as payment responsible.

Previously, users could see all invoices for their students regardless of who was responsible for payment. This caused:
- Access errors (403 Forbidden) when trying to pay invoices
- Incorrect total amounts displayed
- Confusion when multiple payment responsibles exist (e.g., mother/father)

Solution:
Override _get_selected_invoices_domain() to filter invoices by student_id.payment_responsible_ids, ensuring users only see invoices they are responsible for paying.

The fix only applies when account_payment_multi is installed (try/except) to maintain optional dependency and avoid breaking installations without the multi-payment module.