### PR TITLE
[IMP] academic_hr: integrate hr_attendance kiosk filtering

### DIFF
--- a/academic_hr/__manifest__.py
+++ b/academic_hr/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Academic HR",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.3.0",
     "category": "Human Resources",
     "summary": "HR extensions for academic institutions with multiple employee support",
     "author": "ADHOC SA",
@@ -12,6 +12,7 @@
         "hr_timesheet",
         "timesheet_grid",
         "portal",
+        "hr_attendance",
     ],
     "data": [
         "security/academic_hr_security.xml",
@@ -20,6 +21,7 @@
         "views/hr_timesheet_views.xml",
         "views/hr_employee_views.xml",
         "views/hr_leave_allocation_views.xml",
+        "views/hr_attendance_views.xml",
         "views/portal_templates.xml",
     ],
     "assets": {

--- a/academic_hr/controllers/__init__.py
+++ b/academic_hr/controllers/__init__.py
@@ -1,1 +1,2 @@
+from . import hr_attendance
 from . import portal

--- a/academic_hr/controllers/hr_attendance.py
+++ b/academic_hr/controllers/hr_attendance.py
@@ -1,0 +1,51 @@
+from odoo import _, http
+from odoo.addons.hr_attendance.controllers.main import HrAttendance
+from odoo.exceptions import UserError
+from odoo.http import request
+from odoo.osv import expression
+from odoo.tools.image import image_data_uri
+
+
+class HrAttendanceKiosk(HrAttendance):
+    @http.route("/hr_attendance/employees_infos", type="json", auth="public")
+    def employees_infos(self, token, limit, offset, domain):
+        for condition in domain:
+            if not isinstance(condition, (list, tuple)) or len(condition) != 3:
+                continue
+            field_name, operator, _value = condition
+            if field_name not in ("name", "department_id") or operator not in ("=", "ilike"):
+                raise UserError(
+                    _(
+                        "Invalid domain, use 'name' and/or 'department_id' fields with '=' and/or 'ilike' operators.",
+                    )
+                )
+
+        company = self._get_company(token)
+        if company:
+            domain = expression.AND(
+                [
+                    domain,
+                    [("company_id", "=", company.id)],
+                    [
+                        "|",
+                        ("main_employee_id", "!=", False),
+                        ("child_employee_ids", "=", False),
+                    ],
+                ]
+            )
+            employees = (
+                request.env["hr.employee"]
+                .sudo()
+                .search_fetch(domain, ["id", "display_name", "job_id"], limit=limit, offset=offset, order="name, id")
+            )
+            employees_data = [
+                {
+                    "id": employee.id,
+                    "display_name": employee.display_name,
+                    "job_id": employee.job_id.name,
+                    "avatar": image_data_uri(employee.avatar_128),
+                }
+                for employee in employees
+            ]
+            return {"records": employees_data, "length": request.env["hr.employee"].sudo().search_count(domain)}
+        return []

--- a/academic_hr/views/hr_attendance_views.xml
+++ b/academic_hr/views/hr_attendance_views.xml
@@ -1,0 +1,20 @@
+<odoo>
+    <record id="hr_attendance_view_filter" model="ir.ui.view">
+        <field name="name">hr.attenadance.view.filter</field>
+        <field name="model">hr.attendance</field>
+        <field name="inherit_id" ref="hr_attendance.hr_attendance_view_filter"/>
+        <field name="arch" type="xml">
+            <filter name="myattendances" position="before">
+                <filter name="main_employees" string="Main Employees"
+                        domain="[('employee_id.main_employee_id', '=', False)]"/>
+                <filter name="child_employees" string="Child Employees"
+                        domain="[('employee_id.main_employee_id', '!=', False)]"/>
+                <separator/>
+            </filter>
+        </field>
+    </record>
+
+    <record id="hr_attendance.hr_attendance_action" model="ir.actions.act_window">
+        <field name="context">{"search_default_groupby_name": 1, "search_default_employee": 2, "search_default_child_employees": 1}</field>
+    </record>
+</odoo>


### PR DESCRIPTION
Override employees_infos kiosk endpoint to restrict results to main employees (excludes child employees linked via main_employee_id), and add Main/Child Employee filters to the hr.attendance list view with a default context that activates the child employees filter.