### PR TITLE
[FIX] academic_account_interests: fall back to partner when move line…

### DIFF
--- a/academic_account_interests/models/res_company_interest.py
+++ b/academic_account_interests/models/res_company_interest.py
@@ -51,9 +51,9 @@ class ResCompanyInterest(models.Model):
         )
         past_due_rate = self.with_context(debt_past_period=True)._calculate_rate()
         for line in previous_lines:
-            student = line[groupby[0]] if groupby else line.student_id
             partner = line[groupby[1]] if groupby and len(groupby) > 1 else line.partner_id
-            if not student or not partner:
+            student = (line[groupby[0]] if groupby else line.student_id) or partner
+            if not partner:
                 continue
 
             residual_amount = line.amount_residual
@@ -74,11 +74,9 @@ class ResCompanyInterest(models.Model):
             self._get_move_line_domains()
             + [("amount_residual", ">", 0), ("date_maturity", ">=", from_date), ("date_maturity", "<", to_date)]
         )
-        for student, amls in last_period_lines.grouped("student_id").items():
-            if not student:
-                continue
+        for student, amls in last_period_lines.grouped(lambda aml: aml.student_id or aml.partner_id).items():
             partner = amls[:1].partner_id
-            if not partner:
+            if not student or not partner:
                 continue
 
             for move, lines in amls.grouped("move_id").items():
@@ -127,9 +125,9 @@ class ResCompanyInterest(models.Model):
             )
 
             for move_line, parts in partials.items():
-                student = move_line.student_id
                 partner = move_line.partner_id
-                if not student or not partner:
+                student = move_line.student_id or partner
+                if not partner:
                     continue
                 for part in parts:
                     due_date = max(from_date, part.debit_move_id.date_maturity)

--- a/academic_account_interests/tests/__init__.py
+++ b/academic_account_interests/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_interest_student_fallback

--- a/academic_account_interests/tests/test_interest_student_fallback.py
+++ b/academic_account_interests/tests/test_interest_student_fallback.py
@@ -1,0 +1,92 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from dateutil.relativedelta import relativedelta
+from odoo import fields
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestInterestStudentFallback(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        Partner = cls.env["res.partner"]
+
+        cls.sale_journal = cls.env["account.journal"].search(
+            [("type", "=", "sale"), ("company_id", "=", cls.company.id)], limit=1
+        )
+        cls.income_account = cls.env["account.account"].search(
+            [("account_type", "=", "income"), ("company_ids", "in", [cls.company.id])], limit=1
+        )
+        cls.receivable_accounts = cls.env["account.account"].search(
+            [("account_type", "=", "asset_receivable"), ("company_ids", "in", [cls.company.id])]
+        )
+
+        cls.interest_product = cls.env["product.product"].create({"name": "Interest 70280", "type": "service"})
+        cls.interest = cls.env["res.company.interest"].create(
+            {
+                "company_id": cls.company.id,
+                "receivable_account_ids": [(6, 0, cls.receivable_accounts.ids)],
+                "interest_product_id": cls.interest_product.id,
+                "rate": 0.08,
+                "rule_type": "monthly",
+                "interval": 1,
+            }
+        )
+
+        cls.customer = Partner.create({"name": "Customer 70280"})
+        cls.family = Partner.create({"name": "Family 70280", "partner_type": "family"})
+        cls.student = Partner.create({"name": "Student 70280", "partner_type": "student", "parent_id": cls.family.id})
+
+        cls.from_date = fields.Date.today()
+        cls.to_date = cls.from_date + relativedelta(months=1)
+        cls.overdue_date = cls.from_date - relativedelta(days=60)
+
+    def _create_overdue_invoice(self, partner, student=None):
+        vals = {
+            "move_type": "out_invoice",
+            "partner_id": partner.id,
+            "journal_id": self.sale_journal.id,
+            "invoice_date": self.overdue_date,
+            "invoice_date_due": self.overdue_date,
+            "invoice_line_ids": [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Line 70280",
+                        "quantity": 1,
+                        "price_unit": 100.0,
+                        "account_id": self.income_account.id,
+                    },
+                )
+            ],
+        }
+        if student:
+            vals["student_id"] = student.id
+        move = self.env["account.move"].create(vals)
+        move.action_post()
+        return move
+
+    def test_debt_included_when_no_student(self):
+        move = self._create_overdue_invoice(self.customer)
+        self.assertFalse(move.student_id)
+
+        deuda = self.interest.with_company(self.company)._calculate_debts(self.from_date, self.to_date)
+
+        self.assertIn(self.customer, deuda)
+        self.assertGreater(deuda[self.customer]["values"].get("Deuda periodos anteriores", 0), 0)
+        self.assertEqual(deuda[self.customer]["values"].get("partner_id"), self.customer)
+
+    def test_debt_grouped_by_student_when_present(self):
+        move = self._create_overdue_invoice(self.family, student=self.student)
+        self.assertEqual(move.student_id, self.student)
+
+        deuda = self.interest.with_company(self.company)._calculate_debts(self.from_date, self.to_date)
+
+        self.assertIn(self.student, deuda)
+        self.assertNotIn(self.family, deuda)
+        self.assertEqual(deuda[self.student]["values"].get("partner_id"), self.family)


### PR DESCRIPTION
… has no student

The _calculate_debts override grouped and keyed receivable move lines by student_id, skipping any line without a student. Initial balance loads (partner=student collapse) create invoices where student_id is not always set on the line, so those debts were silently excluded from the interest calculation. Fall back to partner_id when student_id is missing in the three calculation sections so no debt is lost, keeping student grouping when it exists.

Task-70280