### PR TITLE
[IMP] academic: portal access to invoices for self-payment students' …

### DIFF
--- a/academic/views/res_partner_views.xml
+++ b/academic/views/res_partner_views.xml
@@ -137,9 +137,9 @@
                         </field>
                     </group>
                 </page>
-                <page string="Contactos y Roles" invisible="links_by_student or partner_type not in ['student', 'family'] or self_payment_responsible">
-                    <p invisible="partner_type != 'student' or parent_links_by_student">Los Contactos y Roles son gestionados en <button name="open_commercial_entity" type="object" string="la familia" class="oe_link"/></p>
-                    <field name="student_link_ids" readonly="partner_type == 'student' and not parent_links_by_student">
+                <page string="Contactos y Roles" invisible="links_by_student or partner_type not in ['student', 'family']">
+                    <p invisible="partner_type != 'student' or parent_links_by_student or not parent_id">Los Contactos y Roles son gestionados en <button name="open_commercial_entity" type="object" string="la familia" class="oe_link"/></p>
+                    <field name="student_link_ids" readonly="partner_type == 'student' and parent_id and not parent_links_by_student">
                         <list editable="bottom">
                             <field name="sequence" widget="handle"/>
                             <field name="company_id" column_invisible="1"/>

--- a/academic_sale_subscription/security/academic_security.xml
+++ b/academic_sale_subscription/security/academic_security.xml
@@ -4,4 +4,21 @@
     <record id="base.group_user" model="res.groups">
         <field name="implied_ids" eval="[(4, ref('account.group_delivery_invoice_address'))]"/>
     </record>
+
+    <record id="account_invoice_rule_portal_academic_follower" model="ir.rule">
+        <field name="name">Portal: invoices academic (follower / payment responsible)</field>
+        <field name="model_id" ref="account.model_account_move"/>
+        <field name="domain_force">[
+            ('state', 'not in', ('cancel', 'draft')),
+            ('move_type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')),
+            '|',
+                ('message_partner_ids', 'in', [user.partner_id.id]),
+                ('student_id.payment_responsible_ids', 'in', [user.partner_id.id]),
+        ]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
 </odoo>


### PR DESCRIPTION
…contacts

- Show and enable the "Contactos y Roles" tab for self-payment students without a family (res_partner_views.xml).
- Add a portal ir.rule on account.move so a portal user that is a follower (or payment responsible of the student) can read the invoice, aligning record access with what the list/payment portal controllers already allow.

Task #70866