### PR TITLE
[IMP] academic_sale_subscription: support non-recurring products in order wizard

### DIFF
--- a/academic_sale_subscription/demo/product_template_demo.xml
+++ b/academic_sale_subscription/demo/product_template_demo.xml
@@ -120,6 +120,20 @@
             <field name="academic_product_type">registration</field>
         </record>
 
+        <!-- Producto no recurrente (para ventas puntuales) -->
+        <record id="product_horas_extra" model="product.product">
+            <field name="name">Horas Extra</field>
+            <field name="type">service</field>
+            <field name="recurring_invoice">False</field>
+            <field name="uom_id" ref="uom.product_uom_hour"/>
+            <field name="uom_po_id" ref="uom.product_uom_hour"/>
+            <field name="list_price">2500.0</field>
+            <field name="standard_price">2500.0</field>
+            <field name="categ_id" ref="product.product_category_all"/>
+            <field name="invoice_policy">order</field>
+            <field name="service_type">manual</field>
+        </record>
+
         <!-- Plantillas de Suscripción Académica -->
         <record id="subscription_template_primaria" model="sale.order.template">
             <field name="name">Cotización Primaria</field>

--- a/academic_sale_subscription/wizard/academic_order_wizard.py
+++ b/academic_sale_subscription/wizard/academic_order_wizard.py
@@ -11,9 +11,7 @@ class OrderWizard(models.TransientModel):
     _description = "Academic Order Wizard"
 
     student_ids = fields.Many2many("res.partner", default=lambda self: self.env.context.get("active_ids", []))
-    plan_id = fields.Many2one(
-        "sale.subscription.plan", required=True, compute="_compute_plan", readonly=False, store=True
-    )
+    plan_id = fields.Many2one("sale.subscription.plan", compute="_compute_plan", readonly=False, store=True)
     order_wizard_line_ids = fields.One2many(
         "academic.order.wizard.line",
         "academic_order_wizard_id",
@@ -23,12 +21,25 @@ class OrderWizard(models.TransientModel):
     )
     pricelist_id = fields.Many2one("product.pricelist")
     template_id = fields.Many2one("sale.order.template")
-    next_invoice_date = fields.Date(string="Date of first invoice", required=True)
+    next_invoice_date = fields.Date(string="Date of first invoice")
     status_sale = fields.Selection(
         [("draft", "Draft"), ("confirmed", "Confirmed")], default="draft", help="Status to be given to sales orders."
     )
     validity_date = fields.Date()
     payment_term_id = fields.Many2one("account.payment.term")
+    is_recurring_mode = fields.Boolean(
+        compute="_compute_is_recurring_mode",
+        store=True,
+    )
+
+    @api.depends("order_wizard_line_ids.product_id")
+    def _compute_is_recurring_mode(self):
+        for rec in self:
+            lines_with_product = rec.order_wizard_line_ids.filtered("product_id")
+            if not lines_with_product:
+                rec.is_recurring_mode = True
+            else:
+                rec.is_recurring_mode = any(line.product_id.recurring_invoice for line in lines_with_product)
 
     def action_create_mass_subscription(self):
         if not self.student_ids:
@@ -50,52 +61,65 @@ class OrderWizard(models.TransientModel):
                 )
             )
 
-        subscriptions = self._create_mass_subscription()
+        orders = self._create_mass_subscription()
 
-        action = self.env.ref("sale_subscription.sale_subscription_action").read()[0]
-        action.update(
-            {
-                "domain": [("id", "in", subscriptions.ids)],
-                "views": sorted(action["views"], key=lambda v: v[1] != "list"),  # show list view first
-                "context": {"default_is_subscription": 1},
+        if self.is_recurring_mode:
+            action = self.env.ref("sale_subscription.sale_subscription_action").read()[0]
+            action.update(
+                {
+                    "domain": [("id", "in", orders.ids)],
+                    "views": sorted(action["views"], key=lambda v: v[1] != "list"),  # show list view first
+                    "context": {"default_is_subscription": 1},
+                }
+            )
+        else:
+            action = {
+                "type": "ir.actions.act_window",
+                "name": self.env._("Orders"),
+                "res_model": "sale.order",
+                "view_mode": "list,form",
+                "domain": [("id", "in", orders.ids)],
             }
-        )
         return action
 
     def _create_mass_subscription(self):
-        subscriptions = self.env["sale.order"]
+        orders = self.env["sale.order"]
         for student in self.student_ids:
-            subscription = self.env["sale.order"].create(
-                {
-                    "partner_id": student.id,
-                    "plan_id": self.plan_id.id,
-                    "pricelist_id": self.pricelist_id.id,
-                    "start_date": self.next_invoice_date,
-                    "sale_order_template_id": self.template_id.id,
-                    "validity_date": self.validity_date if self.status_sale == "draft" else False,
-                    **({"payment_term_id": self.payment_term_id.id} if self.payment_term_id else {}),
-                    "order_line": [
-                        (
-                            0,
-                            0,
-                            {
-                                "product_id": line.product_id.id,
-                                "product_uom_qty": line.quantity,
-                                "price_unit": line.price,
-                                **({"name": line.description} if line.description else {}),
-                                **({"group_id": line.academic_group_id.id} if line.academic_group_id else {}),
-                            },
-                        )
-                        for line in self.order_wizard_line_ids
-                    ],
-                }
-            )
+            order_vals = {
+                "partner_id": student.id,
+                "pricelist_id": self.pricelist_id.id,
+                "validity_date": self.validity_date if self.status_sale == "draft" else False,
+                **({"payment_term_id": self.payment_term_id.id} if self.payment_term_id else {}),
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": line.product_id.id,
+                            "product_uom_qty": line.quantity,
+                            "price_unit": line.price,
+                            **({"name": line.description} if line.description else {}),
+                            **({"group_id": line.academic_group_id.id} if line.academic_group_id else {}),
+                        },
+                    )
+                    for line in self.order_wizard_line_ids
+                ],
+            }
+            if self.is_recurring_mode:
+                order_vals.update(
+                    {
+                        "plan_id": self.plan_id.id,
+                        "start_date": self.next_invoice_date,
+                        "sale_order_template_id": self.template_id.id,
+                    }
+                )
+            order = self.env["sale.order"].create(order_vals)
 
             if self.status_sale == "confirmed":
-                subscription.action_confirm()
+                order.action_confirm()
 
-            subscriptions += subscription
-        return subscriptions
+            orders += order
+        return orders
 
     @api.depends("template_id")
     def _compute_plan(self):
@@ -142,14 +166,27 @@ class OrderWizard(models.TransientModel):
 
             products = rec.template_id.sale_order_template_line_ids.mapped("product_id")
             for wizard_line in rec.order_wizard_line_ids.filtered(lambda x: x.product_id not in products):
-                pricing = self.env["sale.subscription.pricing"]._get_first_suitable_recurring_pricing(
-                    wizard_line.product_id, rec.plan_id, rec.pricelist_id
-                )
-                wizard_line.write({"price": pricing.price if pricing else 0.0})
+                if wizard_line.product_id.recurring_invoice:
+                    pricing = self.env["sale.subscription.pricing"]._get_first_suitable_recurring_pricing(
+                        wizard_line.product_id, rec.plan_id, rec.pricelist_id
+                    )
+                    wizard_line.write({"price": pricing.price if pricing else 0.0})
+                else:
+                    pricelist = rec.pricelist_id
+                    if pricelist:
+                        price = pricelist._get_product_price(
+                            wizard_line.product_id,
+                            1.0,
+                            currency=pricelist.currency_id,
+                            date=fields.Datetime.now(),
+                        )
+                    else:
+                        price = wizard_line.product_id.lst_price
+                    wizard_line.write({"price": price})
 
     @api.constrains("next_invoice_date", "validity_date")
     def _check_validity_date(self):
-        for rec in self.filtered(lambda x: x.status_sale == "draft"):
+        for rec in self.filtered(lambda x: x.status_sale == "draft" and x.next_invoice_date and x.validity_date):
             if rec.next_invoice_date < rec.validity_date:
                 raise UserError(self.env._("The date of the next invoice cannot be earlier than the validity date."))
 
@@ -158,6 +195,20 @@ class OrderWizard(models.TransientModel):
         for rec in self:
             if not rec.order_wizard_line_ids:
                 raise ValidationError(self.env._("There must be product lines."))
+
+    @api.constrains("plan_id", "next_invoice_date", "order_wizard_line_ids")
+    def _check_recurring_fields_required(self):
+        for rec in self:
+            lines_with_product = rec.order_wizard_line_ids.filtered("product_id")
+            if not lines_with_product:
+                continue
+            is_recurring = all(line.product_id.recurring_invoice for line in lines_with_product)
+            if not is_recurring:
+                continue
+            if not rec.plan_id:
+                raise ValidationError(self.env._("A subscription plan is required when creating recurring orders."))
+            if not rec.next_invoice_date:
+                raise ValidationError(self.env._("The date of first invoice is required for recurring orders."))
 
     @api.onchange("order_wizard_line_ids")
     def _onchange_notification_price(self):
@@ -190,13 +241,25 @@ class AcademicOrderWizardLine(models.TransientModel):
         related="product_id.academic_product_type",
     )
 
-    @api.depends("product_id")
+    @api.depends("product_id", "academic_order_wizard_id.plan_id", "academic_order_wizard_id.pricelist_id")
     def _compute_price(self):
         for rec in self.filtered("product_id"):
-            pricing = self.env["sale.subscription.pricing"]._get_first_suitable_recurring_pricing(
-                rec.product_id, rec.academic_order_wizard_id.plan_id, rec.academic_order_wizard_id.pricelist_id
-            )
-            rec.price = pricing.price if pricing else 0.0
+            if rec.product_id.recurring_invoice:
+                pricing = self.env["sale.subscription.pricing"]._get_first_suitable_recurring_pricing(
+                    rec.product_id, rec.academic_order_wizard_id.plan_id, rec.academic_order_wizard_id.pricelist_id
+                )
+                rec.price = pricing.price if pricing else 0.0
+            else:
+                pricelist = rec.academic_order_wizard_id.pricelist_id
+                if pricelist:
+                    rec.price = pricelist._get_product_price(
+                        rec.product_id,
+                        1.0,
+                        currency=pricelist.currency_id,
+                        date=fields.Datetime.now(),
+                    )
+                else:
+                    rec.price = rec.product_id.lst_price
 
     @api.depends("academic_product_type")
     def _compute_academic_group_id(self):

--- a/academic_sale_subscription/wizard/academic_order_wizard_views.xml
+++ b/academic_sale_subscription/wizard/academic_order_wizard_views.xml
@@ -6,14 +6,19 @@
             <form>
                 <group>
                     <group>
-                        <field name="template_id"/>
-                        <field name="plan_id" options="{'no_create': 1}"/>
+                        <field name="is_recurring_mode" invisible="1"/>
+                        <field name="template_id" invisible="not is_recurring_mode"/>
+                        <field name="plan_id" options="{'no_create': 1}"
+                               invisible="not is_recurring_mode"
+                               required="is_recurring_mode"/>
                         <field name="pricelist_id" groups="product.group_product_pricelist"/>
                         <field name="status_sale" widget="radio" options="{'horizontal': true}"/>
                     </group>
                     <group>
                         <field name="validity_date" invisible="status_sale != 'draft'" required="status_sale == 'draft'"/>
-                        <field name="next_invoice_date"/>
+                        <field name="next_invoice_date"
+                               invisible="not is_recurring_mode"
+                               required="is_recurring_mode"/>
                         <field name="payment_term_id"/>
                     </group>
                 </group>


### PR DESCRIPTION
Backport de #424 (19.0) a 18.0.

El wizard `academic.order.wizard` estaba cableado para suscripciones (`plan_id` y `next_invoice_date` siempre requeridos, siempre creaba una OV con plan). Se agrega soporte para **ventas puntuales de productos no recurrentes** desde el mismo wizard.

- Detección de modo por líneas: alguna línea recurrente → flujo suscripción (sin cambios); todas no recurrentes → OV común sin `plan_id`/`start_date`.
- `plan_id` y `next_invoice_date` pasan a requeridos condicionalmente (constraint server-side + `required=is_recurring_mode` en la vista).
- Pricing no recurrente vía `pricelist._get_product_price` (el helper de pricing recurrente devuelve vacío para no recurrentes).
- `_check_validity_date` protegido contra `next_invoice_date=False`.
- Producto demo `product_horas_extra` (no recurrente) para QA.

Adaptación v19→v18: pricing recurrente vía `sale.subscription.pricing._get_first_suitable_recurring_pricing`.

Probado en base v18 con demo: OV no recurrente sin plan (ok), constraint recurrente sin plan (ok), flujo suscripción original intacto (ok).

Task: #71216