### PR TITLE
[FIX] academic: add multi-company record rule on res.partner.link

### DIFF
--- a/academic/security/academic_security.xml
+++ b/academic/security/academic_security.xml
@@ -35,6 +35,13 @@
         <field name="domain_force">['|',('company_id', 'in', company_ids),('company_id','=',False)]</field>
     </record>
 
+    <record model="ir.rule" id="partner_link_multi_company">
+        <field name="name">partner link multi-company</field>
+        <field name="model_id" search="[('model','=','res.partner.link')]" model="ir.model"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">['|',('company_id', 'in', company_ids),('company_id','=',False)]</field>
+    </record>
+
     <!-- We deactivate multicompany rule over multicompany to aboid errors -->
     <!-- <record model="ir.rule" id="base.res_company_rule">
         <field name="active" eval="False"/>


### PR DESCRIPTION
res.partner.link had no record rule, so users could read links of students belonging to companies they have no access to. With a paying contact shared across companies (company_id=False), opening an invoice raised an AccessError: account.move._compute_student_ids searches the links of the payer and maps student_id, reading partners of the other company.

Add a global multi-company rule (same pattern as group_multi_company) so each company only sees its own student links, while shared links (company_id=False) and multi-company users keep full visibility.