### PR TITLE
[IMP] academic_sale_subscription: hide lead address and language on opportunity

### DIFF
--- a/academic_sale_subscription/views/crm_lead_views.xml
+++ b/academic_sale_subscription/views/crm_lead_views.xml
@@ -28,6 +28,15 @@
                 <button string="Create Academic Structure" type="object" name="action_create_family"
                     class="btn-primary" invisible="not family_member_ids"/>
             </xpath>
+            <xpath expr="//page[@name='lead']//label[@for='street_page_lead']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//page[@name='lead']//div[hasclass('o_address_format')]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//page[@name='lead']//field[@name='lang_id']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
             <xpath expr="//notebook" position="inside">
                 <page string="Family Group" name="family">
                     <field name="suggested_family_count" invisible="1"/>


### PR DESCRIPTION
Task 68880

### What

Hides the **address** and the **language** of the *Company Information* group, on the **Contacts** tab of the opportunity form, from `academic_sale_subscription`.

The *company name* (`partner_name`) stays visible: the website registration form stores there the name of the responsible adult. What is noise for schools is the rest of the block — the customer address and language are not used, the customer is created from the **Family Group** tab (`family_member_ids` + `action_create_family`).

> Previous revision of this PR hid the whole *Company Information* group. Changed after functional feedback on the task: hiding the group also hid the responsible adult's name.

### How

The group has no `name` attribute and its `string` is translated, so it cannot be used as an xpath selector (`_valid_inheritance` raises *"View inheritance may not use attribute 'string' as a selector"*). The three elements are reached directly, scoped to the Contacts page:

```xml
<xpath expr="//page[@name='lead']//label[@for='street_page_lead']" position="attributes">
    <attribute name="invisible">1</attribute>
</xpath>
<xpath expr="//page[@name='lead']//div[hasclass('o_address_format')]" position="attributes">
    <attribute name="invisible">1</attribute>
</xpath>
<xpath expr="//page[@name='lead']//field[@name='lang_id']" position="attributes">
    <attribute name="invisible">1</attribute>
</xpath>
```

The fields are hidden, not removed — still readable by import/API.

### Scope

- `partner_name`, *Contact Information*, *Marketing* and *Ownership* stay visible.
- Lead form untouched: the whole Contacts page is natively `invisible="type == 'lead'"`, and the *Extra Info* tab is not modified.
- Only affects databases with the education vertical installed.
- Lead → opportunity conversion (`_create_customer`) is unchanged.

### Test plan

Module updated on a local 19.0 build, no view error. Combined `crm.lead` form arch read through the ORM (`get_view`), Contacts page:

| Group | Element | `invisible` |
|---|---|---|
| Company Information | `partner_name` | – |
| Company Information | Address label + `o_address_format` (`street`, `street2`, `city`, `state_id`, `zip`, `country_id`) | `1` |
| Company Information | `lang_id` | `1` |
| Contact Information | `contact_name`, `function`, `website` | – |
| Marketing | `campaign_id`, `medium_id`, `source_id`, `referred` | – |
| Ownership | `company_id`, `team_id` | – |

All the fields are still present in the arch.
