### PR TITLE
[FIX] academic_sale_subscription: show linked students' subscriptions in portal

### DIFF
--- a/academic_sale_subscription/controllers/customer_portal.py
+++ b/academic_sale_subscription/controllers/customer_portal.py
@@ -3,6 +3,18 @@ from odoo.http import request, route
 
 
 class AcademicPortal(CustomerPortal):
+    def _get_subscription_domain(self, partner):
+        domain = super()._get_subscription_domain(partner)
+        students = partner.sudo().partner_link_ids.student_id
+        if not students:
+            return domain
+        rest = [leaf for leaf in domain if leaf[0] != "partner_id"]
+        return [
+            "|",
+            ("partner_id", "child_of", partner.commercial_partner_id.id),
+            ("partner_id", "in", students.ids),
+        ] + rest
+
     @route()
     def subscription(
         self, order_id, access_token=None, message="", message_class="", report_type=None, download=False, **kw

--- a/academic_sale_subscription/security/academic_security.xml
+++ b/academic_sale_subscription/security/academic_security.xml
@@ -21,4 +21,17 @@
         <field name="perm_create" eval="False"/>
         <field name="perm_unlink" eval="False"/>
     </record>
+
+    <record id="sale_order_rule_portal_academic_student" model="ir.rule">
+        <field name="name">Portal: subscriptions of linked students</field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="domain_force">[
+            ('partner_id.student_link_ids.partner_id', 'in', [user.partner_id.id]),
+        ]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
 </odoo>


### PR DESCRIPTION
## Problema

En bases académicas la suscripción se emite a nombre del **alumno**, mientras que el usuario del portal es un contacto relacionado (responsable de pago, padre/madre, etc.).

El dominio estándar de `sale_subscription` filtra por `partner_id child_of` el commercial partner del usuario, así que el contacto nunca veía las suscripciones: `subscription_count` daba 0 y, como la tarjeta del portal se renderiza con `d-none` y solo la destapa el JS cuando el contador es mayor a 0, el tile de Suscripciones directamente no aparecía. Las facturas del mismo alumno sí se veían, porque para `account.move` ya existe una regla de portal equivalente en este módulo.

## Cambio

- `_get_subscription_domain`: se ensancha **solo** la condición sobre el partner, sumando los alumnos vinculados al usuario vía `res.partner.link`. El resto del dominio estándar (`subscription_state`, `is_subscription`) queda intacto.
- Nueva record rule de portal sobre `sale.order` con el criterio simétrico.

Las dos capas son necesarias: cambiar solo el dominio del controller no tiene ningún efecto, porque la regla de portal estándar (`partner_id child_of` del commercial partner) se **intersecta** con él y vuelve a dejar el contador en 0.

Cualquier rol del vínculo habilita la visibilidad, espejando la regla ya existente para facturas.

## Alcance

No hace falta tocar `res.partner`: las plantillas del portal de suscripciones no referencian `partner_id`, y el detalle resuelve por `_document_check_access`, que devuelve el registro en sudo.

## Test plan

Verificado sobre una base de test con la regla aplicada en transacción:

- Usuarios de portal con `subscription_count > 0`: **0 → 212 de 216** (los 4 restantes no tienen vínculo con alumnos con suscripción activa).
- Lectura de la suscripción como usuario portal: OK (antes `AccessError`).
- Las 298 suscripciones activas están a nombre de un partner con `partner_type = 'student'`.

Para revisar: entrar al portal con un contacto que tenga rol sobre un alumno con suscripción activa y confirmar que aparece el tile "Suscripciones" en `/my` y el listado en `/my/subscriptions`.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/126539