### PR TITLE
[FIX] academic_sale_subscription: apply the grouping rule when invoicing manually

### DIFF
--- a/academic_sale_subscription/models/sale_order.py
+++ b/academic_sale_subscription/models/sale_order.py
@@ -46,8 +46,7 @@ class SaleOrder(models.Model):
 
     def _prepare_invoice(self):
         res = super()._prepare_invoice()
-        if self.is_academic_sale:
-            res["student_id"] = self.partner_id.id
+        res["student_id"] = self.partner_id.id if self.is_academic_sale else False
         return res
 
     @api.model_create_multi
@@ -78,6 +77,12 @@ class SaleOrder(models.Model):
                     "partner_ids": payment_responsible.ids,
                 }
         return default_recipients
+
+    def _get_invoice_grouping_keys(self):
+        grouping_keys = super()._get_invoice_grouping_keys()
+        if any(self.mapped("is_academic_sale")):
+            grouping_keys = grouping_keys + ["student_id", "invoice_payment_term_id"]
+        return grouping_keys
 
     def _get_auto_invoice_grouping_keys(self):
         grouping_keys = super()._get_auto_invoice_grouping_keys() + [

--- a/academic_sale_subscription/tests/__init__.py
+++ b/academic_sale_subscription/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_archive_family_debt
+from . import test_invoice_grouping

--- a/academic_sale_subscription/tests/test_invoice_grouping.py
+++ b/academic_sale_subscription/tests/test_invoice_grouping.py
@@ -1,0 +1,106 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestInvoiceGrouping(TransactionCase):
+    """Facturar a mano no junta en una misma factura ventas de distinto alumno ni de distinto termino
+    de pago, aunque compartan el responsable de pago."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Partner = cls.env["res.partner"]
+
+        cls.relationship = cls.env["res.partner.relationship"].create({"name": "Test Grouping Relationship"})
+        cls.paying_role = cls.env.ref("academic.paying_role")
+
+        cls.family = Partner.create({"name": "Family Grouping"})
+        cls.family.write({"partner_type": "family"})
+        cls.responsible = Partner.create(
+            {"name": "Responsible Grouping", "partner_type": "parent", "vat": "20-22222222-2"}
+        )
+        cls.env["res.partner.link"].create(
+            {
+                "student_id": cls.family.id,
+                "partner_id": cls.responsible.id,
+                "relationship_id": cls.relationship.id,
+                "role_ids": [(6, 0, [cls.paying_role.id])],
+            }
+        )
+        cls.student = Partner.create(
+            {"name": "Student Grouping", "partner_type": "student", "parent_id": cls.family.id}
+        )
+        cls.sibling = Partner.create(
+            {"name": "Sibling Grouping", "partner_type": "student", "parent_id": cls.family.id}
+        )
+
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Grouping Fee",
+                "type": "service",
+                "invoice_policy": "order",
+                "list_price": 100.0,
+            }
+        )
+        cls.payment_term_a = cls.env.ref("account.account_payment_term_immediate")
+        cls.payment_term_b = cls.env.ref("account.account_payment_term_30days")
+
+    @classmethod
+    def _create_order(cls, student, payment_term):
+        order = cls.env["sale.order"].create(
+            {
+                "partner_id": student.id,
+                "payment_term_id": payment_term.id,
+                "order_line": [(0, 0, {"product_id": cls.product.id, "product_uom_qty": 1})],
+            }
+        )
+        order.action_confirm()
+        return order
+
+    def test_different_payment_terms_are_not_merged(self):
+        """El caso del ticket: un alumno con dos cuotas que vencen distinto dia."""
+        orders = self._create_order(self.student, self.payment_term_a) | self._create_order(
+            self.student, self.payment_term_b
+        )
+
+        invoices = orders._create_invoices()
+
+        self.assertEqual(len(invoices), 2)
+        self.assertEqual(invoices.mapped("invoice_payment_term_id"), self.payment_term_a | self.payment_term_b)
+
+    def test_same_payment_term_is_merged(self):
+        """Sin diferencia de termino de pago ni de alumno, la consolidacion sigue siendo la de siempre."""
+        orders = self._create_order(self.student, self.payment_term_a) | self._create_order(
+            self.student, self.payment_term_a
+        )
+
+        invoices = orders._create_invoices()
+
+        self.assertEqual(len(invoices), 1)
+
+    def test_different_students_are_not_merged(self):
+        """Dos hermanos comparten responsable de pago pero cada uno factura por separado."""
+        orders = self._create_order(self.student, self.payment_term_a) | self._create_order(
+            self.sibling, self.payment_term_a
+        )
+
+        invoices = orders._create_invoices()
+
+        self.assertEqual(len(invoices), 2)
+        self.assertEqual(invoices.mapped("student_id"), self.student | self.sibling)
+
+    def test_mixed_academic_and_regular_batch(self):
+        """Un lote que mezcla una venta de alumno con una venta al mismo responsable, que no es academica."""
+        self.env.company.require_student_on_invoices = False
+        regular_order = self._create_order(self.responsible, self.payment_term_a)
+        self.assertFalse(regular_order.is_academic_sale)
+        orders = self._create_order(self.student, self.payment_term_a) | regular_order
+
+        invoices = orders._create_invoices()
+
+        self.assertEqual(len(invoices), 2)
+        self.assertEqual(invoices.student_id, self.student)


### PR DESCRIPTION
Academic defines its own invoice grouping rule for subscriptions: sales of a different student, a different payment responsible or a different payment term are not merged into the same invoice. The rule was only applied to the automatic subscription invoicing, through `_get_auto_invoice_grouping_keys()`.

Invoicing from the **Create Invoice** button goes through `_get_invoice_grouping_keys()`, which was not overridden, so it fell back to the standard keys. Both subscriptions of a student were merged into a single invoice that kept only one of the due dates. Same orders, same month: the result depended on which path created the invoice.

### About the keys

`_get_invoice_grouping_keys()` is evaluated on the invoice values, not on the order (see `_create_invoices` in `sale`), so the keys are not the ones used by the automatic path:

* the student is `student_id`, set by the `_prepare_invoice()` of this module;
* the payment term is `invoice_payment_term_id`;
* `partner_id` is already the payment responsible, and is part of the standard keys.

The override is guarded by `is_academic_sale`, following what `sale_subscription` does with `is_subscription`, because `_get_invoice_grouping_keys()` is used by every sale order of the database.

### Test plan

`academic_sale_subscription/tests/test_invoice_grouping.py`:

* two orders of the same student with different payment terms produce two invoices, one per term;
* two orders of the same student with the same payment term still produce a single invoice;
* two orders of different students sharing the payment responsible produce two invoices.

Without the fix the first test fails with `1 != 2`.

18.0 has the same code and needs the same fix.

Task: https://www.adhoc.inc/odoo/project.task/73646